### PR TITLE
API response fixes and upgrade AMS

### DIFF
--- a/app/controllers/spree/api/paypal_controller.rb
+++ b/app/controllers/spree/api/paypal_controller.rb
@@ -71,7 +71,7 @@ module Spree
         # else
         #   redirect_to checkout_state_path(order.state)
         # end
-        respond_with order
+        render json: order.to_json, status: 200
       end
 
       def cancel

--- a/app/controllers/spree/api/paypal_controller.rb
+++ b/app/controllers/spree/api/paypal_controller.rb
@@ -39,9 +39,9 @@ module Spree
           if pp_response.success?
             url = provider.express_checkout_url(pp_response, :useraction => 'commit')
             
-            response = Spree::Paypal.new
-            response.redirect_url = url
-            respond_with response
+            @paypal_response = Spree::Paypal.new
+            @paypal_response.redirect_url = url
+            respond_with @paypal_response
           else
             # this one is easy we can just respond with pp_response errors
             render json: {errors:pp_response.errors.collect(&:long_message).join(" ")}, status: 500

--- a/app/controllers/spree/api/paypal_controller.rb
+++ b/app/controllers/spree/api/paypal_controller.rb
@@ -38,10 +38,9 @@ module Spree
           pp_response = provider.set_express_checkout(pp_request)
           if pp_response.success?
             url = provider.express_checkout_url(pp_response, :useraction => 'commit')
-            
             @paypal_response = Spree::Paypal.new
             @paypal_response.redirect_url = url
-            respond_with @paypal_response
+            render json: @paypal_response.to_json, status: 200
           else
             # this one is easy we can just respond with pp_response errors
             render json: {errors:pp_response.errors.collect(&:long_message).join(" ")}, status: 500

--- a/app/views/spree/api/paypal/express.v1.rabl
+++ b/app/views/spree/api/paypal/express.v1.rabl
@@ -1,1 +1,0 @@
-object @paypal_response

--- a/app/views/spree/api/paypal/express.v1.rabl
+++ b/app/views/spree/api/paypal/express.v1.rabl
@@ -1,0 +1,1 @@
+object @paypal_response

--- a/spree_paypal_express.gemspec
+++ b/spree_paypal_express.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', '~> 2.4.0'
   s.add_dependency 'spree_api', '~> 2.4.0'
   s.add_dependency 'paypal-sdk-merchant', '1.106.1'
-  s.add_dependency 'active_model_serializers', '~> 0.8.2'
+  s.add_dependency 'active_model_serializers', '0.9.0.alpha1'
 
   s.add_development_dependency 'capybara', '~> 2.1'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
AMS upgraded to match other plugins such as [spree_wombat](https://github.com/spree/spree_wombat/blob/2-4-stable/spree_wombat.gemspec#L17).
